### PR TITLE
add testcases and change Spec.hs

### DIFF
--- a/ch8/test/simplemodules/Spec.hs
+++ b/ch8/test/simplemodules/Spec.hs
@@ -15,7 +15,7 @@ import Control.Exception(try, throw, SomeException)
 main :: IO ()
 main = 
   hspec $ do 
-    describe "exceptions" $ do
+    describe "simplemodules" $ do
       let atdir f = "SIMEPLE-MODULES:" ++ f
       let TypeDeclTestSuite typechecker_tests' = typechecker_tests
 
@@ -39,12 +39,15 @@ doTest (TDTC tcname expr_text maybeResult) =
               (aLexer lexerSpec)
               (fromToken (endOfToken lexerSpec))
 
-      let expression = fromASTExp expressionAst
+      let expression = 
+            case expressionAst of
+              ASTExp e -> Program [] (fromASTExp expressionAst)
+              ASTProgram p -> fromASTProgram expressionAst
 
       -- Just to add the type of x!
       case maybeResult of 
         Just ty' ->
-          do eitherTyOrErr <- typeCheck (Let_Exp "x" (Const_Exp 1) expression)
+          do eitherTyOrErr <- typeCheck expression
              case eitherTyOrErr of
               Left errMsg ->
                 putStrLn ("Expected " ++ show ty' ++ " but got " ++ errMsg ++ " in " ++ show expression)
@@ -53,7 +56,7 @@ doTest (TDTC tcname expr_text maybeResult) =
                     then putStr "" -- putStrLn "Successfully typechecked."
                     else putStrLn ("Expected " ++ show ty' ++ " but got " ++ show ty ++ " in " ++ show expression)
         Nothing ->
-          do eitherTyOrErr <- typeCheck (Let_Exp "x" (Const_Exp 1) expression)
+          do eitherTyOrErr <- typeCheck expression
              case eitherTyOrErr of
               Left errMsg -> putStr "" -- putStrLn "Successfully type-unchecked." -- Is it the same error?
               Right ty -> putStr "" -- putStrLn "Should not be typechecked."


### PR DESCRIPTION
- mwand/eopl/chapter8/simplemodules/test-suite.scm 의 테스트케이스들을 추가했습니다.

- 모듈이 없는 테스트케이스와 모듈이 있는 테스트케이스 모두를 커버하기 위해 
   파싱된 AST를 expression으로 변환하는 과정을 분리하도록 수정했습니다.
    (typeCheck 함수가 Program을 인자로 받도록 유지)

- 테스트 케이스 중 의도된 ParseError와 ErrorCall는 아직 Spec.hs에서 처리되지 않아 실패로 뜹니다.
![화면 캡처 2024-11-17 162936](https://github.com/user-attachments/assets/fc698dad-7443-47a4-90e8-98a536183bff)