### PR TITLE
fix pingpong1

### DIFF
--- a/ch5/app/actors/examples/pingpong1.actor
+++ b/ch5/app/actors/examples/pingpong1.actor
@@ -14,7 +14,7 @@ let pingServer =
                           end
                   )
             else begin print (600); ready (pingServer_self) end
-        in pingServer_self
+        in ready(pingServer_self)
 in            
 let master = 
       proc(self)
@@ -41,7 +41,7 @@ let master =
               end 
             else begin print(500); ready (master_self) end
 
-        in master_self
+        in ready(master_self)
 in let StartMsg = 0 in
    let PingMsg = 1 in
    let PongMsg = 2 in


### PR DESCRIPTION
- 무한루프 현상

master, pingServer 코드에서

proc (self)
      letrec  master_self  (msg) = 
                ...
      in  master_self  

1. master_self를 letrec 함수로 작성
2. 그러면 letrec의 in 식이 먼저 평가
3. master_self는 Var_Exp 로 평가되고 apply_env를 통해 Proc_Val 생성

이 프로시저가 실행되려면 호출 Call_Exp 가 필요한데 
actor에서는 인자를 기다려야 했기 때문에 master_self 로만 작성

그러나 인자를 주지 않으면 pingpong1 실행 시 무한루프 같은 상태로 종료되지 않음

=> 
proc (self)
      letrec  master_self  (msg) = 
                ...
      in  ready(master_self)
  
인자를 기다려야한다는 점에서 ready(master_self) , ready(pingServer_self)이 
적절할 것 같아 수정해보았는데 검토 부탁드립니다!


![image](https://github.com/user-attachments/assets/4bb4ba7c-49d8-406d-a201-4ff2886376f3)

수정 후 정상 작동까진 아니지만 프로그램 종료는 되는 상태가 되었습니다.