### PR TITLE
suggestions for run_next_actor

### DIFF
--- a/ch5/app/actors/Scheduler.hs
+++ b/ch5/app/actors/Scheduler.hs
@@ -45,20 +45,41 @@ decrement_timer :: SchedState -> SchedState
 decrement_timer scState = scState { the_time_remaining = the_time_remaining scState - 1 }
 
 -- Actors
+-- run_next_actor :: Store -> SchedState -> ActorState -> (FinalAnswer, Store) 
+-- run_next_actor store scState (current, q, actorSpace) =
+--   run_next_actor' (current, q, store, scState) actorSpace
+
+-- run_next_actor' :: ActorInfo -> ActorSpace -> (FinalAnswer, Store)
+-- run_next_actor' (currActor, _, _, _) (next, []) = 
+--   error ("Blocking: " ++ show currActor) -- Todo: better way to handle this?
+
+-- run_next_actor' currentActorInfo (next, actorList) = 
+--   let actorList1 = actorList ++ [currentActorInfo]
+--       (nextCurrent, nextQ, nextStore, nextScState) = head actorList1 
+--       actorState1 = (nextCurrent, nextQ, (next, tail actorList1))
+--   in if isempty (the_ready_queue nextScState)
+--      then if null (tail actorList1)
+--           then (fromJust (the_final_answer nextScState), nextStore)
+--           else run_next_actor' currentActorInfo (next, tail actorList1)
+--      else run_next_thread nextStore nextScState actorState1
+
 run_next_actor :: Store -> SchedState -> ActorState -> (FinalAnswer, Store) 
-run_next_actor store scState (current, q, actorSpace) =
-  run_next_actor' (current, q, store, scState) actorSpace
+run_next_actor store scState (current, q, (next, actorList)) =
+  case actorList of
+    [] -> run_next_thread store scState (current, q, (next, actorList))
+    _  -> run_next_actor' (current, q, store, scState) (next, actorList)
 
 run_next_actor' :: ActorInfo -> ActorSpace -> (FinalAnswer, Store)
-run_next_actor' (currActor, _, _, _) (next, []) = 
-  error ("Blocking: " ++ show currActor) -- Todo: better way to handle this?
+run_next_actor' (current, q, store, scState) (next, x:xs) =
+  if isempty (the_ready_queue scState)
+  then let (nextCurrent, nextQ, nextStore, nextScState) = x
+       in if isempty (the_ready_queue nextScState)
+          then run_next_actor nextStore nextScState (nextCurrent, nextQ, (next, xs))
+          else run_next_thread nextStore nextScState (nextCurrent, nextQ, (next, xs))
 
-run_next_actor' currentActorInfo (next, actorList) = 
-  let actorList1 = actorList ++ [currentActorInfo]
-      (nextCurrent, nextQ, nextStore, nextScState) = head actorList1 
-      actorState1 = (nextCurrent, nextQ, (next, tail actorList1))
-  in if isempty (the_ready_queue nextScState)
-     then if null (tail actorList1)
-          then (fromJust (the_final_answer nextScState), nextStore)
-          else run_next_actor' currentActorInfo (next, tail actorList1)
-     else run_next_thread nextStore nextScState actorState1
+  else let actorList1 = (x:xs) ++ [(current, q, store, scState)] -- currentActorInfo
+           (nextCurrent, nextQ, nextStore, nextScState) = head actorList1
+           actorState1 = (nextCurrent, nextQ, (next, tail actorList1))
+       in if isempty (the_ready_queue nextScState)
+          then run_next_actor nextStore nextScState actorState1
+          else run_next_thread nextStore nextScState actorState1

--- a/ch5/app/actors/examples/pingpong2.actor
+++ b/ch5/app/actors/examples/pingpong2.actor
@@ -1,0 +1,44 @@
+let master = 
+      proc(self)
+	let pingServer = 
+	      proc(self)
+		letrec pingServer_self (msg) =
+		    let PingMsg = 1 in
+		    let PongMsg = 2 in
+		    if zero? (-(msg, PingMsg))
+		    then ready ( proc (masterSelf)
+				  begin
+				    print (300);
+				    send (masterSelf, PongMsg);
+				    send (masterSelf, self)
+				  end
+			  )
+		    else begin print (600); ready (pingServer_self) end
+		in ready(pingServer_self)
+	in
+        letrec master_self (msg) =
+            let StartMsg = 0 in
+            let PingMsg = 1 in
+            let PongMsg = 2 in
+            if zero? (-(msg,StartMsg))
+            then
+              let p = new(pingServer) in
+                begin
+                  print(200);
+                  send (p, PingMsg);
+                  send (p, self);
+                  ready (master_self)
+                end
+            else if zero? (-(msg, PongMsg))
+            then
+              begin print(400)
+              end 
+            else begin print(500); ready (master_self) end
+
+        in ready(master_self)
+in let StartMsg = 0 in
+   let m = new (master) in 
+     begin 
+       print (100); 
+       send (m, StartMsg)
+     end


### PR DESCRIPTION
- 지난 pr 코멘트에 수정해주신 pingpong예제 코드를 pingpong2.actor로 파일 추가했습니다.


- 기존 run_next_actor 문제점
![image](https://github.com/user-attachments/assets/1388b141-ac26-48da-a628-f50222616708)
액터 생성안하는 예제는 정상 종료 불가

- 기존 run_next_actor, run_next_actor' 동작 분석
![image](https://github.com/user-attachments/assets/2028f2d9-3d9d-4e98-8b76-58825e7222c1)
let actorList1 = actorList ++ [currentActorInfo] 로 항상 현재 액터 정보를 액터 리스트에 추가.
이 때문에 액터 리스트가 []인 경우가 없어 무한 루프 발생 추측.

- 수정 제안
![image](https://github.com/user-attachments/assets/da580210-45ea-468c-9ab6-b2116828afa1)

1. run_next_actor 에서 액터 리스트가 비었는지 검사하도록 로직 변경
2. run_next_actor' 에서 현재 액터 레디큐 검사 후 액터 리스트에 추가할지 안할지 결정

- 수정 후 pingpong2.actor 실행
![image](https://github.com/user-attachments/assets/09966207-3b72-44ca-8cc1-ae186664bf66)

수정 후 이제 종료는 되지만, 액터 종료 시점을 액터의 스케줄러 레디 큐가 비어있는 시점으로 보는 게 적절한지는 좀 더 다른 경우들을 살펴봐야 할 것 같습니다.

수정 제안 검토 부탁드립니다
