### PR TITLE
multi pingpong send args : only Send_Exp ver.

### DIFF
--- a/ch5/app/actors/EnvStore.hs
+++ b/ch5/app/actors/EnvStore.hs
@@ -155,9 +155,9 @@ sendmsg' to v ((name, q, store, sched):actorList)
 
 sendAllmsg :: ActorName -> [ExpVal] -> ActorState -> ActorState
 sendAllmsg _ [] actors = actors
-sendAllmsg actorName (x:xs) actors =
-  let actors1 = sendmsg actorName x actors
-  in sendAllmsg actorName xs actors1
+sendAllmsg to (v:vs) actors =
+  let actors1 = sendmsg to v actors
+  in sendAllmsg to vs actors1
 
 readymsg :: ActorState -> Maybe (ExpVal, ActorState)
 readymsg (current, q, actorSpace) 

--- a/ch5/app/actors/Expr.hs
+++ b/ch5/app/actors/Expr.hs
@@ -27,11 +27,10 @@ data Exp =
   -- | Raise_Exp  Exp                        -- raise exp
 
   -- For Actors
-  | Send_Exp  Exp Exp                     -- send ( actor, value )
+  | Send_Exp [ Exp ]                      -- send ( to , msgs ) -> send ( SendExpressionList )
   | Ready_Exp Exp                         -- ready ( expression ) 
   | New_Exp   Exp                         -- new ( expression )
   | Eq_Actor_Exp Exp Exp                  -- actor? ( actor, actor )
-  | Args_Exp [ Exp ]
   deriving Show
 
 data UnaryOp = IsZero | IsNull | Car | Cdr | Print deriving Show

--- a/ch5/app/actors/Parser.hs
+++ b/ch5/app/actors/Parser.hs
@@ -59,13 +59,13 @@ parserSpec = ParserSpec
       rule "Expression -> ( Expression Expression )"
         (\rhs -> return $ Call_Exp (get rhs 2) (get rhs 3)),
 
-      rule "Expression -> begin ExpressionList end"
+      rule "Expression -> begin BlockExpressionList end"
         (\rhs -> return $ get rhs 2),
 
-      rule "ExpressionList -> Expression"
+      rule "BlockExpressionList -> Expression"
         (\rhs -> return $ Block_Exp [ get rhs 1 ]),
 
-      rule "ExpressionList -> Expression ; ExpressionList"
+      rule "BlockExpressionList -> Expression ; BlockExpressionList"
         (\rhs -> return $
                    case get rhs 3 of
                      Block_Exp exprs -> Block_Exp (get rhs 1 : exprs)),
@@ -116,16 +116,16 @@ parserSpec = ParserSpec
         (\rhs -> return $ Unary_Exp Print (get rhs 3)),
 
       -- Actors
-      rule "Expression -> send ( Expression , ExpressionArgsList )"
-        (\rhs -> return $ Send_Exp (get rhs 3) (get rhs 5)),
+      rule "Expression -> send ( SendExpressionList )"
+        (\rhs -> return $ (get rhs 3)),
 
-      rule "ExpressionArgsList -> Expression"
-        (\rhs -> return $ Args_Exp [get rhs 1]),
+      rule "SendExpressionList -> Expression"
+        (\rhs -> return $ Send_Exp [ get rhs 1 ]),
 
-      rule "ExpressionArgsList -> Expression , ExpressionArgsList"
+      rule "SendExpressionList -> Expression , SendExpressionList"
         (\rhs ->
             case get rhs 3 of
-              Args_Exp exprs -> return $ Args_Exp (get rhs 1 : exprs)),
+              Send_Exp exprs -> return $ Send_Exp (get rhs 1 : exprs)),
 
       rule "Expression -> ready ( Expression )"
         (\rhs -> return $ Ready_Exp (get rhs 3)),


### PR DESCRIPTION
### 변경 사항

1.  EnvStore :  sendAllmsg 변수명만 변경

2.  Expr :  Send_Exp Exp Exp --> Send_Exp [ Exp ] 로 변경

3.  Interp :
    -  Send_Cont [Exp] [ExpVal] Env Cont 로 변경
    -  Send 관련 value_of_k 및 apply_cont' 추가
    -  사용하지 않는 보조함수 삭제

4.  Parser 
    - 비단말 이름을 Send에 관한 Exp 리스트임을 나타내기 위해 SendExpressionList 로 변경
    - 혼선을 피하기 위해 begin end 규칙에서 Exp 리스트의 비단말 이름도 BlockExpressionList 로 변경

p.s.
기존 커밋 기록과 통일성을 유지하기 위해 send args를 썼습니다. 다른 대체할 표현은 좀 더 고민해보겠습니다.

