### PR TITLE
fix run_next_actor'

### DIFF
--- a/ch5/app/actors/Scheduler.hs
+++ b/ch5/app/actors/Scheduler.hs
@@ -35,6 +35,7 @@ run_next_thread store scState actors =
           ( scState { the_ready_queue = other_ready_threads,
                       the_time_remaining = the_max_time_slice scState } ) actors )
 
+
 set_final_answer :: SchedState -> ExpVal -> SchedState
 set_final_answer scState val = scState { the_final_answer = Just val }
 
@@ -45,41 +46,21 @@ decrement_timer :: SchedState -> SchedState
 decrement_timer scState = scState { the_time_remaining = the_time_remaining scState - 1 }
 
 -- Actors
--- run_next_actor :: Store -> SchedState -> ActorState -> (FinalAnswer, Store) 
--- run_next_actor store scState (current, q, actorSpace) =
---   run_next_actor' (current, q, store, scState) actorSpace
-
--- run_next_actor' :: ActorInfo -> ActorSpace -> (FinalAnswer, Store)
--- run_next_actor' (currActor, _, _, _) (next, []) = 
---   error ("Blocking: " ++ show currActor) -- Todo: better way to handle this?
-
--- run_next_actor' currentActorInfo (next, actorList) = 
---   let actorList1 = actorList ++ [currentActorInfo]
---       (nextCurrent, nextQ, nextStore, nextScState) = head actorList1 
---       actorState1 = (nextCurrent, nextQ, (next, tail actorList1))
---   in if isempty (the_ready_queue nextScState)
---      then if null (tail actorList1)
---           then (fromJust (the_final_answer nextScState), nextStore)
---           else run_next_actor' currentActorInfo (next, tail actorList1)
---      else run_next_thread nextStore nextScState actorState1
 
 run_next_actor :: Store -> SchedState -> ActorState -> (FinalAnswer, Store) 
 run_next_actor store scState (current, q, (next, actorList)) =
   case actorList of
-    [] -> run_next_thread store scState (current, q, (next, actorList))
-    _  -> run_next_actor' (current, q, store, scState) (next, actorList)
+    [] -> run_next_thread store scState (current, q, (next, actorList))   -- If no actors are waiting, continue executing self
+    _  -> run_next_actor' (current, q, store, scState) (next, actorList)  -- If there are waiting actors, run_next_actor' with self-info
 
 run_next_actor' :: ActorInfo -> ActorSpace -> (FinalAnswer, Store)
 run_next_actor' (current, q, store, scState) (next, x:xs) =
-  if isempty (the_ready_queue scState)
-  then let (nextCurrent, nextQ, nextStore, nextScState) = x
-       in if isempty (the_ready_queue nextScState)
-          then run_next_actor nextStore nextScState (nextCurrent, nextQ, (next, xs))
-          else run_next_thread nextStore nextScState (nextCurrent, nextQ, (next, xs))
+  if isempty (the_ready_queue scState)   -- checking the current actor's ready queue
+  then let (nextCurrent, nextQ, nextStore, nextScState) = x                       -- If empty, the current actor is not added to the waiting list
+       in run_next_thread nextStore nextScState (nextCurrent, nextQ, (next, xs))  -- the next actor executes
 
-  else let actorList1 = (x:xs) ++ [(current, q, store, scState)] -- currentActorInfo
-           (nextCurrent, nextQ, nextStore, nextScState) = head actorList1
+  else let actorList1 = (x:xs) ++ [(current, q, store, scState)]                  -- If not empty, the current actor is added to the waiting list
+           (nextCurrent, nextQ, nextStore, nextScState) = head actorList1         -- the next actor executes
            actorState1 = (nextCurrent, nextQ, (next, tail actorList1))
-       in if isempty (the_ready_queue nextScState)
-          then run_next_actor nextStore nextScState actorState1
-          else run_next_thread nextStore nextScState actorState1
+       in run_next_thread nextStore nextScState actorState1
+

--- a/ch5/app/actors/examples/dining_philosopher.actor
+++ b/ch5/app/actors/examples/dining_philosopher.actor
@@ -1,0 +1,112 @@
+let phil = proc(self)
+                let left = 0 in
+                let right = 0 in
+                let sticks = 0 in
+
+                    letrec phil_self (msg) =
+                        let Chop = 0 in
+                        let Pickup = 1 in
+                        let Release = 2 in
+
+                        if zero?(-(msg, Chop))
+                        then ready( proc(cl)
+                                        begin
+                                            set left = cl;
+                                            ready( proc(cr)
+                                                    set right = cr );
+                                            print(300);
+                                            ready(phil_self)
+                                        end )
+
+                        else if zero?(-(msg, Pickup))
+                             then if zero?(-(sticks, 0))
+                                  then  begin
+                                            set sticks = 1;
+                                            print(301);
+                                            ready(phil_self)
+                                        end
+                                  else  begin
+                                            set sticks = 2;
+                                            send (left, Release, self);
+                                            send (right, Release, self);
+                                            print(302);
+                                            ready(phil_self)
+                                        end
+                             
+                             else if zero?(-(msg, Release))
+                                  then if zero?(-(sticks, 2))
+                                       then begin 
+                                                set sticks = 1;
+                                                print(400);
+                                                ready(phil_self) 
+                                            end
+                                        else begin set sticks = 0; print(401) end
+                                  else ready(phil_self)
+                    
+                    in ready(phil_self)
+in
+let chopstick = proc(self)
+                    let nil = new(proc(d) 42) in
+                    let having = nil in
+                    let waiting = nil in
+
+                    letrec chopstick_self (msg) =
+                        let Pickup = 1 in
+                        let Release = 2 in
+
+                        if zero?(-(msg, Pickup))
+                        then if actor?(having, nil)
+                             then ready( proc(phil) 
+                                            begin
+                                                send(phil, Pickup);
+                                                set having = phil;
+                                                print(200);
+                                                ready(chopstick_self)
+                                            end )
+                             else ready ( proc(phil)
+                                            begin
+                                                set waiting = phil;
+                                                print(201);
+                                                ready(chopstick_self)
+                                            end )
+
+                        else if zero?(-(msg, Release))
+                             then ready( proc(phil)
+                                            begin
+                                                send(phil, Release);
+                                                print(202);
+
+                                                if actor?(waiting, nil)
+                                                then ready(chopstick_self)
+                                                else begin
+                                                        send(waiting, Pickup);
+                                                        set having = waiting;
+                                                        set waiting = nil;
+                                                        ready(chopstick_self)
+                                                     end;
+                                                print(203)
+                                            end )
+                             else ready(chopstick_self)
+                    
+                    in ready(chopstick_self)
+in
+let Chop = 0 in
+let Pickup = 1 in
+
+let c0 = new(chopstick) in
+let c1 = new(chopstick) in
+let p0 = new(phil) in
+let p1 = new(phil) in
+
+begin
+    send(p0, Chop, c0, c1);
+    send(p1, Chop, c1, c0);
+    print(100);
+
+    send(c0, Pickup, p0);
+    send(c1, Pickup, p0);
+    print(101);
+    send(c0, Pickup, p1);
+    send(c1, Pickup, p1);
+    print(102)
+end

--- a/ch5/app/actors/examples/mutual_exclusion.actor
+++ b/ch5/app/actors/examples/mutual_exclusion.actor
@@ -1,0 +1,66 @@
+let sem = proc(self)
+            let state = 0 
+            in
+                letrec sem_self (msg) =
+                    let StartMsg = 0 in
+                    let GetMsg = 1 in
+                    let ReleaseMsg = 2 in
+
+                    if zero?(-(msg, GetMsg))
+                    then if zero?(state)
+                         then ready( proc(from)
+                                        begin
+                                            set state = 1;
+                                            send(from, GetMsg, self);
+                                            print(300);
+                                            ready(sem_self)
+                                        end )
+                         else ready( proc(from)
+                                        begin
+                                            send(from, StartMsg, self);
+                                            print(400);
+                                            ready(sem_self)
+                                        end )
+                    else if zero?(-(msg, ReleaseMsg))
+                         then begin 
+                                set state = 0; 
+                                print(500); 
+                                ready(sem_self) 
+                              end
+                         else ready(sem_self)
+                in
+                ready(sem_self)
+in
+let customer = proc(self)
+                    letrec customer_self (msg) =
+                        let StartMsg = 0 in
+                        let GetMsg = 1 in
+                        let ReleaseMsg = 2 in
+
+                        if zero?(msg)
+                        then ready( proc(s)
+                                        begin
+                                            send(s, GetMsg, self);
+                                            print(200);
+                                            ready(customer_self)
+                                        end )
+                        else if zero?(-(msg, GetMsg))
+                             then ready( proc(s)
+                                            begin
+                                                print(msg);
+                                                send(s, ReleaseMsg)
+                                            end )
+                             else ready(customer_self)
+                    in
+                    ready(customer_self)
+in
+let StartMsg = 0 in
+let s = new(sem) in
+let a1 = new(customer) in
+let a2 = new(customer) in
+    begin
+        send(a1, StartMsg, s);
+        print(100);
+        send(a2, StartMsg, s);
+        print(101)
+    end

--- a/ch5/app/actors/examples/reference_cell.actor
+++ b/ch5/app/actors/examples/reference_cell.actor
@@ -1,0 +1,49 @@
+let cell = 
+      proc (self)
+        let v = 0
+	    in
+            letrec cell_self (msg) =
+                let GetMsg = 0 in
+                let SetMsg = 1 in
+
+                if zero? (-(msg, GetMsg))
+                then
+                    ready( proc (clientActor)
+                            begin
+                                send(clientActor, v);
+                                print(300);
+                                ready(cell_self)
+                            end
+                    )
+
+                else if zero? (-(msg, SetMsg))
+                     then 
+                        ready( proc (value)
+                                begin
+                                    set v = value;
+                                    print(200);
+                                    ready(cell_self)
+                                end
+                        )
+                     else ready(cell_self)
+
+            in ready(cell_self)
+
+in let client =
+        proc (self)
+            letrec client_self (msg) = print(msg)
+            in ready(client_self)
+
+    in 
+        let GetMsg = 0 in
+        let SetMsg = 1 in
+        let a = new(cell) in
+        let c = new(client) in 
+            begin  
+                send(a, SetMsg, 7);
+                print(100);
+                send(a, SetMsg, 2);
+                print(101);
+                send(a, GetMsg, c);
+                print(102)
+            end


### PR DESCRIPTION
사용되지 않는 로직 제거
- 액터 리스트에서 다음 실행할 액터 정보 꺼내봄
- 다음 액터의 레디큐가 비어있는지 검사함
- 그러나 액터 리스트에 존재했다는 것은 실행할 식이 존재한다는 것 (레디큐가 비어있을 수가 없음)

따라서 다음 액터의 레디큐를 검사하고 행동을 달리하는 로직은 의미가 없음