### PR TITLE
add compiled examples

### DIFF
--- a/ch5/app/actors/examples/rpc_to_actor1_comp.actor
+++ b/ch5/app/actors/examples/rpc_to_actor1_comp.actor
@@ -1,0 +1,63 @@
+proc (main)
+  let CREATECLO = 1 in
+  let CALLCLO = 2 in
+  let F2 = 2 in
+  let f2 = proc (fvs3)
+  let (y10, y21) = fvs3 in
+  proc (x4)
+-(-(x4 , y10) , y21) in
+  let dispatch = proc (fNO)
+if zero? (-(fNO , 2))
+  then f2
+  else 0 in
+  letrec
+    mainLoop (msg) = if zero? (-(msg , CREATECLO))
+    then ready (createClo)
+    else if zero? (-(msg , CALLCLO))
+      then ready (callClo)
+      else ready (mainLoop)
+    createClo (msg) =     let (fNO, fvs, sender) = msg in
+    let f = (dispatch fNO) in
+    let clo = (f, fvs) in
+begin send (sender, clo); ready (mainLoop) end
+    callClo (msg) =     let (clo, arg, sender) = msg in
+    let (f, fvs) = clo in
+    let ffvs = (f fvs) in
+    let ret = (ffvs arg) in
+begin send (sender, ret); ready (mainLoop) end
+  in
+    let behaviourb = proc (self)
+  let CREATECLO = 1 in
+  let CALLCLO = 2 in
+  let F2 = 2 in
+  let f2 = proc (fvs3)
+  let (y10, y21) = fvs3 in
+  proc (x4)
+-(-(x4 , y10) , y21) in
+  let dispatch = proc (fNO)
+if zero? (-(fNO , 2))
+  then f2
+  else 0 in
+  letrec
+    mainLoop (msg) = if zero? (-(msg , CREATECLO))
+    then ready (createClo)
+    else if zero? (-(msg , CALLCLO))
+      then ready (callClo)
+      else ready (mainLoop)
+    createClo (msg) =     let (fNO, fvs, sender) = msg in
+    let f = (dispatch fNO) in
+    let clo = (f, fvs) in
+begin send (sender, clo); ready (mainLoop) end
+    callClo (msg) =     let (clo, arg, sender) = msg in
+    let (f, fvs) = clo in
+    let ffvs = (f fvs) in
+    let ret = (ffvs arg) in
+begin send (sender, ret); ready (mainLoop) end
+  in
+ready (mainLoop) in
+    let b = new (behaviourb) in
+    let y10 = 1 in
+    let y21 = 2 in
+begin send (b, CREATECLO, (2, (y10, y21), main)); ready (proc (clo5)
+begin send (b, CALLCLO, (clo5, 2, main)); ready (proc (ret6) begin print(ret6);
+ret6 end) end) end

--- a/ch5/app/actors/examples/rpc_to_actor2_comp.actor
+++ b/ch5/app/actors/examples/rpc_to_actor2_comp.actor
@@ -1,0 +1,62 @@
+proc (main)
+  let CREATECLO = 1 in
+  let CALLCLO = 2 in
+  let F1 = 1 in
+  let f1 = proc (fvs2)
+  let (y0) = fvs2 in
+  proc (x3)
+-(x3 , y0) in
+  let dispatch = proc (fNO)
+if zero? (-(fNO , 1))
+  then f1
+  else 0 in
+  letrec
+    mainLoop (msg) = if zero? (-(msg , CREATECLO))
+    then ready (createClo)
+    else if zero? (-(msg , CALLCLO))
+      then ready (callClo)
+      else ready (mainLoop)
+    createClo (msg) =     let (fNO, fvs, sender) = msg in
+    let f = (dispatch fNO) in
+    let clo = (f, fvs) in
+begin send (sender, clo); ready (mainLoop) end
+    callClo (msg) =     let (clo, arg, sender) = msg in
+    let (f, fvs) = clo in
+    let ffvs = (f fvs) in
+    let ret = (ffvs arg) in
+begin send (sender, ret); ready (mainLoop) end
+  in
+    let behaviourb = proc (self)
+  let CREATECLO = 1 in
+  let CALLCLO = 2 in
+  let F1 = 1 in
+  let f1 = proc (fvs2)
+  let (y0) = fvs2 in
+  proc (x3)
+-(x3 , y0) in
+  let dispatch = proc (fNO)
+if zero? (-(fNO , 1))
+  then f1
+  else 0 in
+  letrec
+    mainLoop (msg) = if zero? (-(msg , CREATECLO))
+    then ready (createClo)
+    else if zero? (-(msg , CALLCLO))
+      then ready (callClo)
+      else ready (mainLoop)
+    createClo (msg) =     let (fNO, fvs, sender) = msg in
+    let f = (dispatch fNO) in
+    let clo = (f, fvs) in
+begin send (sender, clo); ready (mainLoop) end
+    callClo (msg) =     let (clo, arg, sender) = msg in
+    let (f, fvs) = clo in
+    let ffvs = (f fvs) in
+    let ret = (ffvs arg) in
+begin send (sender, ret); ready (mainLoop) end
+  in
+ready (mainLoop) in
+    let b = new (behaviourb) in
+    let y0 = 1 in
+begin send (b, CREATECLO, (1, (y0), main)); ready (proc (clo4)
+begin send (b, CALLCLO, (clo4, 2, main)); ready (proc (ret5) begin print(ret5);
+ret5 end) end) end

--- a/ch5/app/actors/examples/rpc_to_actor3_comp.actor
+++ b/ch5/app/actors/examples/rpc_to_actor3_comp.actor
@@ -1,0 +1,116 @@
+proc (main)
+  let CREATECLO = 1 in
+  let CALLCLO = 2 in
+  let F0 = 0 in
+  let f0 = proc (fvs1)
+  let () = fvs1 in
+  proc (x2)
+begin send (b, CREATECLO, (4, (x2), a)); ready (proc (clo7)
+clo7) end in
+  let F4 = 4 in
+  let f4 = proc (fvs5)
+  let (x2) = fvs5 in
+  proc (y6)
+-(x2 , y6) in
+  let dispatch = proc (fNO)
+if zero? (-(fNO , 0))
+  then f0
+  else if zero? (-(fNO , 4))
+    then f4
+    else 0 in
+  letrec
+    mainLoop (msg) = if zero? (-(msg , CREATECLO))
+    then ready (createClo)
+    else if zero? (-(msg , CALLCLO))
+      then ready (callClo)
+      else ready (mainLoop)
+    createClo (msg) =     let (fNO, fvs, sender) = msg in
+    let f = (dispatch fNO) in
+    let clo = (f, fvs) in
+begin send (sender, clo); ready (mainLoop) end
+    callClo (msg) =     let (clo, arg, sender) = msg in
+    let (f, fvs) = clo in
+    let ffvs = (f fvs) in
+    let ret = (ffvs arg) in
+begin send (sender, ret); ready (mainLoop) end
+  in
+    let behavioura = proc (self)
+  let CREATECLO = 1 in
+  let CALLCLO = 2 in
+  let F0 = 0 in
+  let f0 = proc (fvs1)
+  let () = fvs1 in
+  proc (x2)
+begin send (b, CREATECLO, (4, (x2), a)); ready (proc (clo7)
+clo7) end in
+  let F4 = 4 in
+  let f4 = proc (fvs5)
+  let (x2) = fvs5 in
+  proc (y6)
+-(x2 , y6) in
+  let dispatch = proc (fNO)
+if zero? (-(fNO , 0))
+  then f0
+  else if zero? (-(fNO , 4))
+    then f4
+    else 0 in
+  letrec
+    mainLoop (msg) = if zero? (-(msg , CREATECLO))
+    then ready (createClo)
+    else if zero? (-(msg , CALLCLO))
+      then ready (callClo)
+      else ready (mainLoop)
+    createClo (msg) =     let (fNO, fvs, sender) = msg in
+    let f = (dispatch fNO) in
+    let clo = (f, fvs) in
+begin send (sender, clo); ready (mainLoop) end
+    callClo (msg) =     let (clo, arg, sender) = msg in
+    let (f, fvs) = clo in
+    let ffvs = (f fvs) in
+    let ret = (ffvs arg) in
+begin send (sender, ret); ready (mainLoop) end
+  in
+ready (mainLoop) in
+    let a = new (behavioura) in
+    let behaviourb = proc (self)
+  let CREATECLO = 1 in
+  let CALLCLO = 2 in
+  let F0 = 0 in
+  let f0 = proc (fvs1)
+  let () = fvs1 in
+  proc (x2)
+begin send (b, CREATECLO, (4, (x2), a)); ready (proc (clo7)
+clo7) end in
+  let F4 = 4 in
+  let f4 = proc (fvs5)
+  let (x2) = fvs5 in
+  proc (y6)
+-(x2 , y6) in
+  let dispatch = proc (fNO)
+if zero? (-(fNO , 0))
+  then f0
+  else if zero? (-(fNO , 4))
+    then f4
+    else 0 in
+  letrec
+    mainLoop (msg) = if zero? (-(msg , CREATECLO))
+    then ready (createClo)
+    else if zero? (-(msg , CALLCLO))
+      then ready (callClo)
+      else ready (mainLoop)
+    createClo (msg) =     let (fNO, fvs, sender) = msg in
+    let f = (dispatch fNO) in
+    let clo = (f, fvs) in
+begin send (sender, clo); ready (mainLoop) end
+    callClo (msg) =     let (clo, arg, sender) = msg in
+    let (f, fvs) = clo in
+    let ffvs = (f fvs) in
+    let ret = (ffvs arg) in
+begin send (sender, ret); ready (mainLoop) end
+  in
+ready (mainLoop) in
+    let b = new (behaviourb) in
+begin send (a, CREATECLO, (0, (), main)); ready (proc (clo3)
+begin send (a, CALLCLO, (clo3, 1, main)); ready (proc (ret8)
+begin send (b, CALLCLO, (ret8, 2, main)); ready (proc (ret9) begin print(ret9);
+ret9 end) end) end) end

--- a/ch5/app/actors/examples/rpc_to_actor3_comp.actor
+++ b/ch5/app/actors/examples/rpc_to_actor3_comp.actor
@@ -1,116 +1,145 @@
 proc (main)
   let CREATECLO = 1 in
   let CALLCLO = 2 in
+
   let F0 = 0 in
   let f0 = proc (fvs1)
-  let () = fvs1 in
-  proc (x2)
-begin send (b, CREATECLO, (4, (x2), a)); ready (proc (clo7)
-clo7) end in
+            let () = fvs1 in
+            proc (x2)
+                begin send (b, CREATECLO, (4, (x2), a)); ready (proc (clo7) clo7) end in
+
   let F4 = 4 in
   let f4 = proc (fvs5)
-  let (x2) = fvs5 in
-  proc (y6)
--(x2 , y6) in
+            let (x2) = fvs5 in
+            proc (y6)
+                -(x2 , y6) in
+
   let dispatch = proc (fNO)
-if zero? (-(fNO , 0))
-  then f0
-  else if zero? (-(fNO , 4))
-    then f4
-    else 0 in
+                    if zero? (-(fNO , 0))
+                    then f0
+                    else if zero? (-(fNO , 4))
+                         then f4
+                         else 0 in
   letrec
-    mainLoop (msg) = if zero? (-(msg , CREATECLO))
-    then ready (createClo)
-    else if zero? (-(msg , CALLCLO))
-      then ready (callClo)
-      else ready (mainLoop)
-    createClo (msg) =     let (fNO, fvs, sender) = msg in
-    let f = (dispatch fNO) in
-    let clo = (f, fvs) in
-begin send (sender, clo); ready (mainLoop) end
-    callClo (msg) =     let (clo, arg, sender) = msg in
-    let (f, fvs) = clo in
-    let ffvs = (f fvs) in
-    let ret = (ffvs arg) in
-begin send (sender, ret); ready (mainLoop) end
+    mainLoop (msg) = 
+        if zero? (-(msg , CREATECLO))
+        then ready (createClo)
+        else if zero? (-(msg , CALLCLO))
+             then ready (callClo)
+             else ready (mainLoop)
+    
+    createClo (msg) =
+        let (fNO, fvs, sender) = msg in
+        let f = (dispatch fNO) in
+        let clo = (f, fvs) in
+        begin send (sender, clo); ready (mainLoop) end
+    
+    callClo (msg) =
+        let (clo, arg, sender) = msg in
+        let (f, fvs) = clo in
+        let ffvs = (f fvs) in
+        let ret = (ffvs arg) in
+        begin send (sender, ret); ready (mainLoop) end
   in
+
     let behavioura = proc (self)
-  let CREATECLO = 1 in
-  let CALLCLO = 2 in
-  let F0 = 0 in
-  let f0 = proc (fvs1)
-  let () = fvs1 in
-  proc (x2)
-begin send (b, CREATECLO, (4, (x2), a)); ready (proc (clo7)
-clo7) end in
-  let F4 = 4 in
-  let f4 = proc (fvs5)
-  let (x2) = fvs5 in
-  proc (y6)
--(x2 , y6) in
-  let dispatch = proc (fNO)
-if zero? (-(fNO , 0))
-  then f0
-  else if zero? (-(fNO , 4))
-    then f4
-    else 0 in
-  letrec
-    mainLoop (msg) = if zero? (-(msg , CREATECLO))
-    then ready (createClo)
-    else if zero? (-(msg , CALLCLO))
-      then ready (callClo)
-      else ready (mainLoop)
-    createClo (msg) =     let (fNO, fvs, sender) = msg in
-    let f = (dispatch fNO) in
-    let clo = (f, fvs) in
-begin send (sender, clo); ready (mainLoop) end
-    callClo (msg) =     let (clo, arg, sender) = msg in
-    let (f, fvs) = clo in
-    let ffvs = (f fvs) in
-    let ret = (ffvs arg) in
-begin send (sender, ret); ready (mainLoop) end
+                        let CREATECLO = 1 in
+                        let CALLCLO = 2 in
+                        let F0 = 0 in
+                        let f0 = proc (fvs1)
+                                    let () = fvs1 in
+                                        proc (x2)
+                                            begin send (b, CREATECLO, (4, (x2), a)); 
+                                                  ready (proc (clo7) clo7) 
+                                            end 
+                        in
+    let F4 = 4 in
+    let f4 = proc (fvs5)
+                let (x2) = fvs5 in
+                    proc (y6)
+                        -(x2 , y6) in
+    
+    let dispatch = proc (fNO)
+                    if zero? (-(fNO , 0))
+                    then f0
+                    else if zero? (-(fNO , 4))
+                    then f4
+                    else 0 in
+    letrec
+        mainLoop (msg) = 
+            if zero? (-(msg , CREATECLO))
+            then ready (createClo)
+            else if zero? (-(msg , CALLCLO))
+            then ready (callClo)
+            else ready (mainLoop)
+    
+        createClo (msg) =
+            let (fNO, fvs, sender) = msg in
+            let f = (dispatch fNO) in
+            let clo = (f, fvs) in
+                begin send (sender, clo); ready (mainLoop) end
+    
+        callClo (msg) = 
+            let (clo, arg, sender) = msg in
+            let (f, fvs) = clo in
+            let ffvs = (f fvs) in
+            let ret = (ffvs arg) in
+            begin send (sender, ret); ready (mainLoop) end
+  in ready (mainLoop) 
+  
   in
-ready (mainLoop) in
     let a = new (behavioura) in
     let behaviourb = proc (self)
-  let CREATECLO = 1 in
-  let CALLCLO = 2 in
-  let F0 = 0 in
-  let f0 = proc (fvs1)
-  let () = fvs1 in
-  proc (x2)
-begin send (b, CREATECLO, (4, (x2), a)); ready (proc (clo7)
-clo7) end in
+                        let CREATECLO = 1 in
+                        let CALLCLO = 2 in
+                        let F0 = 0 in
+                        let f0 = proc (fvs1)
+                                    let () = fvs1 in
+                                    proc (x2) begin send (b, CREATECLO, (4, (x2), a)); 
+                                                    ready (proc (clo7) clo7) 
+                                              end in
   let F4 = 4 in
   let f4 = proc (fvs5)
-  let (x2) = fvs5 in
-  proc (y6)
--(x2 , y6) in
+            let (x2) = fvs5 in
+            proc (y6) -(x2 , y6) in
+  
   let dispatch = proc (fNO)
-if zero? (-(fNO , 0))
-  then f0
-  else if zero? (-(fNO , 4))
-    then f4
-    else 0 in
+                    if zero? (-(fNO , 0))
+                    then f0
+                    else if zero? (-(fNO , 4))
+                         then f4
+                         else 0 in
   letrec
-    mainLoop (msg) = if zero? (-(msg , CREATECLO))
-    then ready (createClo)
-    else if zero? (-(msg , CALLCLO))
-      then ready (callClo)
-      else ready (mainLoop)
-    createClo (msg) =     let (fNO, fvs, sender) = msg in
-    let f = (dispatch fNO) in
-    let clo = (f, fvs) in
-begin send (sender, clo); ready (mainLoop) end
-    callClo (msg) =     let (clo, arg, sender) = msg in
-    let (f, fvs) = clo in
-    let ffvs = (f fvs) in
-    let ret = (ffvs arg) in
-begin send (sender, ret); ready (mainLoop) end
+    mainLoop (msg) = 
+        if zero? (-(msg , CREATECLO))
+        then ready (createClo)
+        else if zero? (-(msg , CALLCLO))
+             then ready (callClo)
+             else ready (mainLoop)
+    
+    createClo (msg) =
+        let (fNO, fvs, sender) = msg in
+        let f = (dispatch fNO) in
+        let clo = (f, fvs) in
+        begin send (sender, clo); ready (mainLoop) end
+    
+    callClo (msg) =
+        let (clo, arg, sender) = msg in
+        let (f, fvs) = clo in
+        let ffvs = (f fvs) in
+        let ret = (ffvs arg) in
+        begin send (sender, ret); ready (mainLoop) end
+  
+  in ready (mainLoop) 
+  
   in
-ready (mainLoop) in
     let b = new (behaviourb) in
-begin send (a, CREATECLO, (0, (), main)); ready (proc (clo3)
-begin send (a, CALLCLO, (clo3, 1, main)); ready (proc (ret8)
-begin send (b, CALLCLO, (ret8, 2, main)); ready (proc (ret9) begin print(ret9);
-ret9 end) end) end) end
+    begin send (a, CREATECLO, (0, (), main)); 
+          ready (proc (clo3)
+                    begin send (a, CALLCLO, (clo3, 1, main)); 
+                          ready (proc (ret8)
+                                    begin send (b, CALLCLO, (ret8, 2, main)); 
+                                          ready (proc (ret9) begin print(ret9); ret9 end) 
+                                    end) 
+                    end) 
+    end


### PR DESCRIPTION
수정된 pprint로 출력된 코드의 마지막에 print(ret..)를  추가한 실행용 예제입니다.
- rpc_to_actor1_comp.actor

![1](https://github.com/user-attachments/assets/859f5331-845a-405b-9fbd-1a8389d564af)

-> -1

- rpc_to_actor2_comp.actor
![2](https://github.com/user-attachments/assets/5235e543-8a35-41d4-bf21-b4aadd95030e)

-> 1


- rpc_to_actor3_comp.actor
![3](https://github.com/user-attachments/assets/06c398df-2b47-4e21-8bc3-8e7599ab9578)

-> b를 찾지 못하는 에러 발생