### PR TITLE
refactor : Var_Cont, Proc_Exp

### DIFF
--- a/ch5/app/actors/examples/multitier_actor2.actor
+++ b/ch5/app/actors/examples/multitier_actor2.actor
@@ -4,15 +4,17 @@ let x = 1 in
 letrec inc(x) = -(x, -1) in
 
 let a = new (proc( self )
-           letrec f(msg) =
+            letrec f(msg) =
              let (cmd, nextActor) = msg in
                    if zero?(-(cmd, SET))
                    then begin set x = (inc x);
                               send (nextActor, PRINT);
-                              print(200)
+                              print(200);
+                              let p6 = proc self (x) -(x,- 1) in 
+                                    print((p6 600))
                         end
                    else ready(f)
-           in ready(f) )
+            in ready(f) )
 
 in
 let b = new (proc ( self )
@@ -21,24 +23,22 @@ let b = new (proc ( self )
                   if zero?(-(cmd, PRINT))
                    then print(x)
                    else ready(g)
-             
-           in ready(g) )
+            in ready(g) )
 
 in
-
 letrec p1 a (x) = -(x, -1)
        p2 b (x) = -(x, -1) in
 let p3 = proc a (x) -(x, -1) in
 let p4 = proc b (x) -(x, -1) in
 let p5 = proc (x) -(x,-1) in 
 
-    begin
-        send(a, (SET, b));
-        print(100);
-        let r1 = (p1 100) in print(r1);
-        let r2 = (p2 200) in print(r2);
-        let r3 = (p3 300) in print(r3);
-        let r4 = (p4 400) in print(r4);
-        let r5 = (p5 500) in print(r5);
-        ready(proc(d) print(d))
-    end
+begin
+      send(a, (SET, b));
+      print(100);
+      let r1 = (p1 100) in print(r1);
+      let r2 = (p2 200) in print(r2);
+      let r3 = (p3 300) in print(r3);
+      let r4 = (p4 400) in print(r4);
+      let r5 = (p5 500) in print(r5);
+      ready(proc(d) print(d))
+end


### PR DESCRIPTION
- Var_Cont => Remote_Var_Cont 이름 수정

- Proc 식의 actorName이 현재 액터인지 원격 액터인지 구분해서 처리
-> 테스트 위해 multitier_actor2.actor 수정

     액터 **a** 안에서 자신의 위치를 표시하며 함수를 선언할 때,
     - let p6 = proc **a** (x) -(x,- 1) in      --> 에러 : 변수 a가 액터 a의 환경 안에 저장되어 있지 않음
     - let p6 = proc **self** (x) -(x,- 1) in  --> 가능 : New_cont 로직에서 self가 Actor_Val 과 매핑

![image](https://github.com/user-attachments/assets/0e8e9dd1-b3bc-48d7-8770-fc46456688db)


Q. 
현재 main 액터만 액터 a, b 위치에 대해 원격 함수 생성 가능.
액터 a에서 액터 main에 원격 함수 생성 (코드를 수정하면)가능하지만 액터 b에는 불가능. 
--> 자연스러운 것인지?

