### PR TITLE
tokenring run

### DIFF
--- a/ch5/app/actors/Interp.hs
+++ b/ch5/app/actors/Interp.hs
@@ -216,7 +216,6 @@ apply_cont' (Ready_Cont saved_cont) val store actors = do
   current <- getSelfPid
   receiveWait
     [ match $ \(msg :: RemoteMessage) -> do
-        liftIO $ putStrLn $ "[" ++ show current ++ "] " ++ show msg
         case msg of
           -- 변수 read 요청 처리
           RemoteVar varLoc requester -> do

--- a/ch5/app/actors/examples/splashsrc2025/tokenring.actor
+++ b/ch5/app/actors/examples/splashsrc2025/tokenring.actor
@@ -5,29 +5,27 @@ let TOKEN = 2 in
 let beh = proc(name)
             proc(token)
                 proc(self) 
-                    let tmpToken = token in 
                     letrec h (msg) = 
                         let (cmd, payload) = msg in 
                             if (cmd == START) then 
                                 begin 
-                                    print("[START]" ++ name);
-                                    let next = payload in 
-
+                                    print("\n[START] " ++ name ++ "\n");
+                                    let next = payload in
                                         begin 
                                             if (name == token) then
-                                                print("\n" ++ name ++ "\n")
+                                                print("\nreceived : " ++ name ++ "\n")
                                             else 
-                                                send (next, (TOKEN, token)); 
+                                                send (next, (TOKEN, token));
 
                                             letrec h1(msg) = 
                                                 let (cmd, payload) = msg in 
                                                     if (cmd == TOKEN) then 
-                                                        begin 
+                                                        begin
                                                             let senttoken = payload in 
                                                                 if (name == senttoken) then
                                                                     begin 
                                                                         set token = senttoken ;
-                                                                        print("\n" ++ name ++ "\n")
+                                                                        print("\nreceived : " ++ senttoken ++ "\n")
                                                                     end
                                                                 else 
                                                                     send (next, (TOKEN, senttoken));


### PR DESCRIPTION
- 코드 로직이 변경된 바는 없고
- 인터프리터의 로그 출력 해제하고 예제 코드의 출력만 조금 변형했습니다.

한 터미널에서만 다섯 노드를 출력하다 보니 좀 어그러지긴 했는데

![image](https://github.com/user-attachments/assets/29019adb-da98-44d3-8b7d-f07184e88f8e)

- 출력된 바로는 잘 동작하는 것 같습니다.

그런데 behv가 main에 있어서 인자 name, token도 
extend_env 시 main 위치로 저장되어 원격 변수 참조가 많이 발생하는 것 같습니다.

지금 동작은 안하지만, 아래와 같이 쓸 수도 있지 않을까 싶네요

```
proc(main)
let START = 1 in
let TOKEN = 2 in 
let beh = proc @ring (self)
            proc(name)
            proc(token)
                    letrec h (msg) = 
                        ....
                    in 
                        ready(h) 
in
let node1 = ( ((beh "kim") "park") )
in
let node2 =  ( ((beh "choi" ) "kim") )
in
let node3 =  ( ((beh "park") "choi") )
in
    begin 
        print("main begin");
        send (node1, (START, node2));
        send (node2, (START, node3));
        send (node3, (START, node1));

        ready(proc(d) d)
    end

```

