### PR TITLE
propose revised semantics for New

### DIFF
--- a/ch5/app/actors/EnvStore.hs
+++ b/ch5/app/actors/EnvStore.hs
@@ -216,14 +216,6 @@ initActorState mainNid procMap = ActorState
   , procMap = procMap
   }
 
-data ActorBehavior = ActorBehavior Identifier Exp Env ActorState
-  deriving (Generic, Binary, Typeable)
-
-data ActorMessage =
-    StartActor ActorBehavior ActorId    -- stack run actors-exe node ..
-  | SelectedBehavior Exp Env            -- stack run actors-exe role ...
-  deriving (Generic, Binary, Typeable)
-
 
 -- Messages
 data RemoteMessage = 

--- a/ch5/app/actors/Expr.hs
+++ b/ch5/app/actors/Expr.hs
@@ -34,7 +34,7 @@ data Exp =
   | Send_Exp     [ Exp ]                  -- send ( to , msgs ) -> send ( SendExpressionList )
   | Ready_Exp    Exp                      -- ready ( expression ) 
   | New_Exp      Exp                      -- new ( expression )
-  | Spawn_Exp  Exp                        -- spawn ( expression )
+  -- | Spawn_Exp  Exp                        -- spawn ( expression )
 
   -- For Tuple
   | Tuple_Exp    [ Exp ]                  -- ( expression1, ..., expressionk )
@@ -120,9 +120,9 @@ toProcMap (Ready_Exp e) i m =
 toProcMap (New_Exp e) i m =
   let (i1, m1, e') = toProcMap e i m
   in (i1, m1, New_Exp e')
-toProcMap (Spawn_Exp e) i m =
-  let (i1, m1, e') = toProcMap e i m
-  in (i1, m1, Spawn_Exp e')
+-- toProcMap (Spawn_Exp e) i m =
+--   let (i1, m1, e') = toProcMap e i m
+--   in (i1, m1, Spawn_Exp e')
 toProcMap (Tuple_Exp exps) i m =
   let (i1, m1, exps') =
         foldl (\(i', m', acc) e ->

--- a/ch5/app/actors/NodeRegistry.hs
+++ b/ch5/app/actors/NodeRegistry.hs
@@ -2,11 +2,7 @@
 
 module NodeRegistry
   ( NodeMessage(..)
-  , NodeRegistry
-  , newRegistry
-  , registerNode
-  , assignNode
-  , removeNode
+  , RoleRegistry
   , newRoleRegistry
   , registerRole
   , getPidByRoles
@@ -25,43 +21,11 @@ import Control.Distributed.Process (ProcessId, NodeId)
 
 -- Messages
 data NodeMessage
-  = RegisterNode NodeId
-  | RequestNode ProcessId
-  | AssignNode NodeId
-  | AssignSelf
-
-  | RegisterRole String ProcessId
+  = RegisterRole String ProcessId
   | RequestRole String ProcessId
   | RoleFound [ProcessId]
   | NotFound
   deriving (Generic, Binary, Typeable)
-
--- node Registry functions
-type NodeRegistry = TVar [NodeId]
-
-newRegistry :: IO NodeRegistry
-newRegistry = newTVarIO []
-
-registerNode :: NodeId -> NodeRegistry -> STM ()
-registerNode nid registry = do
-  nids <- readTVar registry
-  if nid `elem` nids
-  then return ()
-  else writeTVar registry (nid : nids)
-
-assignNode :: NodeRegistry -> STM (Maybe NodeId)
-assignNode registry = do
-  nids <- readTVar registry
-  case nids of
-    (nid:rest) -> do
-      writeTVar registry (rest)
-      return (Just nid)
-    [] -> return Nothing
-
-removeNode :: NodeId -> NodeRegistry -> STM ()
-removeNode nid registry = do
-  nids <- readTVar registry
-  writeTVar registry (filter (/= nid) nids)
 
 
 -- role Registry

--- a/ch5/app/actors/Parser.hs
+++ b/ch5/app/actors/Parser.hs
@@ -154,8 +154,8 @@ parserSpec = ParserSpec
       rule "Expression -> new ( Expression )"
         (\rhs -> return $ PETExp (New_Exp (expFrom (get rhs 3)))),
 
-      rule "Expression -> spawn ( Expression )"
-        (\rhs -> return $ PETExp (Spawn_Exp (expFrom (get rhs 3)))),
+      -- rule "Expression -> spawn ( Expression )"
+      --   (\rhs -> return $ PETExp (Spawn_Exp (expFrom (get rhs 3)))),
 
       -- Tuples
       rule "Expression -> ( TupleExpressionList )"

--- a/ch5/app/actors/examples/splashsrc2025/chat_dynamic4.actor
+++ b/ch5/app/actors/examples/splashsrc2025/chat_dynamic4.actor
@@ -25,7 +25,7 @@ let server = new ( proc (self)
 
 in
 let clientBehavior = proc @client (self)
-                        let clientInput = spawn( proc(d)
+                        let clientInput = new ( proc(d)
                                             letrec input (d) = 
                                                 let msg = read() in
                                                 begin


### PR DESCRIPTION
**- stack run actors-exe node ... 삭제**

[사유]
- 메인 노드에서 인터프리터 실행 전에 
   stack run actors-exe node ... 으로 원격 노드(=role이 없는 그냥 워커)들이 접속되어야 의미 있음
- new 시맨틱스 복잡해짐

(기존)
new ( // proc // )

메인 노드가 워커 노드 pool을 관리하고
new 시 인자로 받은 함수의 위치에 대해 로컬/원격 판단 후 
로컬인 경우, 워커 노드가 있다면 자동으로 그쪽에서 액터를 생성하고, 없다면 로컬에서 생성
원격인 경우(=@이 붙은 함수), 해당 원격 위치에서 함수 실행

Elixir나 Cloud Haskell 등 액터 언어들에서는
워커풀 관리/자동 분산을 지원하지 않음
new는 기본적으로 로컬에서 액터 생성을 의미, 원격 액터 생성은 따로 명시
e.g. Elixir
spawn            --> 로컬
spawn(Node, ..) --> 원격

(제안)
new ( // proc // )

new 시 인자로 받은 함수의 위치에 대해 로컬/원격 판단 후
로컬인 경우, 로컬에서 액터 생성
원격인 경우, 해당 원격 위치에서 함수 실행

new ( proc (self) ... )  --> 로컬

let behavProc = proc @/role/ (self) ...
...
new ( ( behavProc pid) ) --> 원격

----

- New_Cont에서 함수가 원격인 경우 SelectedBehavior 메시지로 해당 원격 위치에서 함수 실행
   **-> RemoteCall 메시지로 변경**

SelectedBehavior 메시지 처리 로직이 RemoteCall과 비슷하여 통합해봄, 작동엔 문제 X
그러나 의미적으로 구분하는것이 더 이해에 도움이 될 수도 있을 것 같음
