### PR TITLE
refactor: use proc ID instead of AST for remote

### DIFF
--- a/ch5/app/actors/EnvStore.hs
+++ b/ch5/app/actors/EnvStore.hs
@@ -221,14 +221,14 @@ initActorState mainNid procMap = ActorState
 data RemoteMessage = 
     RemoteVar Location ActorId              -- 원격 store 주소
   | RemoteSet (Location, ExpVal) ActorId    -- (원격 store 주소, 할당할 값)
-  | RemoteProc Exp Env ActorId              -- 생성할 Proc_Exp, Env
+  | RemoteProc Int Env ActorId              -- 생성할 Proc_Exp, Env
   | RemoteCall (ExpVal, ExpVal) ActorId     -- (ratorVal, randVal)
   deriving (Generic, Binary, Typeable)
 
 instance Show RemoteMessage where
   show (RemoteVar loc aid) = "RemoteVar loc: " ++ show loc ++ " from: " ++ show aid
   show (RemoteSet (loc, val) aid) = "RemoteSet loc: " ++ show loc ++ " value: " ++ show val ++ " to: " ++ show aid
-  show (RemoteProc exp env aid) = "RemoteProc exp: " ++ show exp ++ " to: " ++ show aid
+  show (RemoteProc idx env aid) = "RemoteProc Ptr: " ++ show idx ++ " to: " ++ show aid
   show (RemoteCall (val1, val2) aid) = "RemoteCall rator: " ++ show val1 ++ " value: " ++ show val2 ++ " to: " ++ show aid  
 
 data ReturnMessage = ReturnMessage ExpVal


### PR DESCRIPTION
- Remote Proc : 함수 추상 구문 트리를 전달하는 대신 고유 숫자로 지정해서 전달

- begin .. end 구문 지원을 위해
  value_of_k' (Proc_Exp Nothing var body) 은 남겨둠